### PR TITLE
Make analysis paths configurable

### DIFF
--- a/run_analysis.py
+++ b/run_analysis.py
@@ -5,6 +5,7 @@ This script uses the AI Development handlers to extract knowledge from a codebas
 generate documentation, and store knowledge in MongoDB and vector database.
 """
 
+import argparse
 import asyncio
 import os
 import logging
@@ -147,10 +148,24 @@ async def search_code(repo_id, query, search_type="all", limit=10):
 
 async def main():
     """Main entry point"""
-    # Set parameters
-    repo_path = "C:\\workstation\\orbitax-platform-api-fork"
-    output_dir = "C:\\Users\\shaswata\\Documents\\basic-mcp-server\\analysis_output"
-    file_limit = 500  # Limit files for testing
+    parser = argparse.ArgumentParser(description="Analyze a repository and build documentation")
+    parser.add_argument("--repo-path", "--repo", dest="repo_path", default=os.environ.get("REPO_PATH"),
+                        help="Path to the repository to analyze")
+    parser.add_argument("--output-dir", "--output", dest="output_dir",
+                        default=os.environ.get("OUTPUT_DIR", os.path.join(os.path.dirname(__file__), "analysis_output")),
+                        help="Directory to store analysis results")
+    parser.add_argument("--file-limit", dest="file_limit", type=int,
+                        default=int(os.environ.get("FILE_LIMIT", 500)),
+                        help="Maximum number of files to analyze")
+
+    args = parser.parse_args()
+
+    repo_path = args.repo_path
+    if not repo_path:
+        parser.error("Repository path must be provided via --repo-path or REPO_PATH environment variable")
+
+    output_dir = args.output_dir
+    file_limit = args.file_limit
     
     # Run analysis
     print(f"=== ANALYZING REPOSITORY: {repo_path} ===")

--- a/test_analyzer.py
+++ b/test_analyzer.py
@@ -2,10 +2,10 @@
 Test script for enhanced knowledge extractors and documentation building
 """
 
+import argparse
 import os
 import asyncio
 import json
-from pathlib import Path
 
 from mcp_server.services.knowledge_extraction.environment_analyzer import EnvironmentAnalyzer
 from mcp_server.services.knowledge_extraction.pattern_extractor import PatternExtractor
@@ -13,11 +13,19 @@ from mcp_server.services.knowledge_extraction.code_extractor import CodeExtracto
 from mcp_server.services.knowledge_extraction.md_builder import MarkdownBuilder
 
 async def main():
-    # Set repository path
-    repo_path = "C:/workstation/orbitax-platform-api-fork"
-    
-    # Create output directory
-    output_dir = os.path.join(os.path.dirname(__file__), "analysis_output")
+    parser = argparse.ArgumentParser(description="Run knowledge extraction tests")
+    parser.add_argument("--repo-path", "--repo", dest="repo_path", default=os.environ.get("REPO_PATH"),
+                        help="Path to the repository to analyze")
+    parser.add_argument("--output-dir", "--output", dest="output_dir",
+                        default=os.environ.get("OUTPUT_DIR", os.path.join(os.path.dirname(__file__), "analysis_output")),
+                        help="Directory to store analysis results")
+    args = parser.parse_args()
+
+    repo_path = args.repo_path
+    if not repo_path:
+        parser.error("Repository path must be provided via --repo-path or REPO_PATH environment variable")
+
+    output_dir = args.output_dir
     os.makedirs(output_dir, exist_ok=True)
     
     print(f"Analyzing repository: {repo_path}")


### PR DESCRIPTION
## Summary
- add argparse options to run_analysis
- add argparse options to test_analyzer
- read repo and output paths from command line or environment

## Testing
- `python -m py_compile run_analysis.py test_analyzer.py && echo OK`