### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+aiohttp
+aiofiles
+python-dotenv
+websockets
+psutil
+numpy
+motor
+pymongo
+qdrant-client
+networkx


### PR DESCRIPTION
## Summary
- add a `requirements.txt` listing python dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*