### PR TITLE
Improve Azure embedding config

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ The server can be configured using environment variables in the `.env` file:
 | `OPENAI_DEFAULT_MODEL` | Default OpenAI model | "gpt-4o" |
 | `OPENAI_DEFAULT_MAX_TOKENS` | Default max tokens for OpenAI | 1024 |
 | `OPENAI_DEFAULT_TEMPERATURE` | Default temperature for OpenAI | 0.7 |
+| `EMBEDDINGS_3_LARGE_API_URL` | Azure endpoint for `text-embedding-3-large` | None |
+| `EMBEDDINGS_3_LARGE_API_KEY` | API key for `text-embedding-3-large` | None |
+| `EMBEDDINGS_3_SMALL_API_URL` | Azure endpoint for `text-embedding-3-small` | None |
+| `EMBEDDINGS_3_SMALL_API_KEY` | API key for `text-embedding-3-small` | None |
+| `AZURE_OPENAI_EMBEDDING_DEPLOYMENT` | Azure deployment name for embeddings | `<model name>` |
+
+When embedding API credentials are not provided, the server will generate
+deterministic mock embeddings so that testing can proceed without external
+services.
 
 ## Usage
 

--- a/mcp_server/services/embedding_service.py
+++ b/mcp_server/services/embedding_service.py
@@ -25,7 +25,8 @@ class EmbeddingService:
         max_retries: int = 3,
         retry_delay: float = 1.0,
         azure_api_url: Optional[str] = None,
-        azure_api_key: Optional[str] = None
+        azure_api_key: Optional[str] = None,
+        azure_deployment_name: Optional[str] = None,
     ):
         """Initialize the embedding service
         
@@ -48,20 +49,31 @@ class EmbeddingService:
         self.retry_delay = retry_delay
         self.azure_api_url = azure_api_url
         self.azure_api_key = azure_api_key
+        self.azure_deployment_name = (
+            azure_deployment_name
+            or os.environ.get("AZURE_OPENAI_EMBEDDING_DEPLOYMENT")
+            or model.replace("-", "")
+        )
         
-        # Set provider based on model name and configuration
-        if model == "text-embedding-3-large" and self.azure_api_url:
+        # Load Azure credentials from environment if not provided
+        if model == "text-embedding-3-large":
+            self.azure_api_url = self.azure_api_url or os.environ.get(
+                "EMBEDDINGS_3_LARGE_API_URL"
+            )
+            self.azure_api_key = self.azure_api_key or os.environ.get(
+                "EMBEDDINGS_3_LARGE_API_KEY"
+            )
+        elif model == "text-embedding-3-small":
+            self.azure_api_url = self.azure_api_url or os.environ.get(
+                "EMBEDDINGS_3_SMALL_API_URL"
+            )
+            self.azure_api_key = self.azure_api_key or os.environ.get(
+                "EMBEDDINGS_3_SMALL_API_KEY"
+            )
+
+        # Set provider based on available credentials and model
+        if model.startswith("text-embedding-3") and self.azure_api_url and self.azure_api_key:
             self.provider = "azure"
-            # Load from environment if not provided
-            if not self.azure_api_url:
-                self.azure_api_url = os.environ.get("EMBEDDINGS_3_LARGE_API_URL")
-                self.azure_api_key = os.environ.get("EMBEDDINGS_3_LARGE_API_KEY")
-        elif model == "text-embedding-3-small" and self.azure_api_url:
-            self.provider = "azure"
-            # Load from environment if not provided
-            if not self.azure_api_url:
-                self.azure_api_url = os.environ.get("EMBEDDINGS_3_SMALL_API_URL")
-                self.azure_api_key = os.environ.get("EMBEDDINGS_3_SMALL_API_KEY")
         elif model.startswith("text-embedding"):
             self.provider = "openai"
         elif model.startswith("claude"):
@@ -145,7 +157,10 @@ class EmbeddingService:
             List of embedding vectors
         """
         if not self.openai_api_key:
-            raise ValueError("OpenAI API key not configured")
+            self.logger.warning(
+                "OpenAI API key not configured, using mock embeddings"
+            )
+            return [self.create_mock_embedding(text) for text in texts]
         
         # Prepare API request
         headers = {
@@ -186,7 +201,10 @@ class EmbeddingService:
             List of embedding vectors
         """
         if not self.anthropic_api_key:
-            raise ValueError("Anthropic API key not configured")
+            self.logger.warning(
+                "Anthropic API key not configured, using mock embeddings"
+            )
+            return [self.create_mock_embedding(text) for text in texts]
         
         # Anthropic doesn't support batch embedding yet, so we need to process one by one
         embeddings = []
@@ -233,7 +251,10 @@ class EmbeddingService:
             List of embedding vectors
         """
         if not self.azure_api_key or not self.azure_api_url:
-            raise ValueError("Azure OpenAI API key or URL not configured")
+            self.logger.warning(
+                "Azure OpenAI credentials not configured, using mock embeddings"
+            )
+            return [self.create_mock_embedding(text) for text in texts]
         
         # Prepare API request
         headers = {
@@ -243,12 +264,13 @@ class EmbeddingService:
         
         data = {
             "input": texts,
-            "encoding_format": "float"
+            "model": self.model,
+            "encoding_format": "float",
         }
         
         # Determine API version and endpoint
         api_version = "2023-05-15"
-        deployment_name = self.model.replace("-", "")  # Azure needs deployment name without hyphens
+        deployment_name = self.azure_deployment_name
         
         # Make API request
         async with aiohttp.ClientSession() as session:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+aiohttp
+aiofiles
+python-dotenv
+websockets
+psutil
+numpy
+motor
+pymongo
+qdrant-client
+networkx


### PR DESCRIPTION
## Summary
- configure azure embedding deployment name
- add fallback to mock embeddings when API keys are missing
- document Azure embedding variables and mock fallback

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*