### PR TITLE
Clean __init__ files and export packages

### DIFF
--- a/mcp_server/__init__.py
+++ b/mcp_server/__init__.py
@@ -1,1 +1,13 @@
-﻿
+"""MCP Server package exports."""
+
+from .config import MCPServerConfig
+from .core import MCPServer
+from .services import AIServiceRegistry, create_ai_services_from_config
+
+__all__ = [
+    "MCPServerConfig",
+    "MCPServer",
+    "AIServiceRegistry",
+    "create_ai_services_from_config",
+]
+

--- a/mcp_server/config/__init__.py
+++ b/mcp_server/config/__init__.py
@@ -1,1 +1,6 @@
-﻿
+"""Configuration helpers for MCP Server."""
+
+from .settings import MCPServerConfig
+
+__all__ = ["MCPServerConfig"]
+

--- a/mcp_server/core/__init__.py
+++ b/mcp_server/core/__init__.py
@@ -1,1 +1,6 @@
-﻿
+"""Core server interfaces."""
+
+from .server import MCPServer, HandlerInterface
+
+__all__ = ["MCPServer", "HandlerInterface"]
+

--- a/mcp_server/models/__init__.py
+++ b/mcp_server/models/__init__.py
@@ -1,1 +1,16 @@
-﻿
+"""JSON-RPC model exports."""
+
+from .json_rpc import (
+    MCPRequest,
+    MCPResponse,
+    JSONRPCErrorCode,
+    StreamChunk,
+)
+
+__all__ = [
+    "MCPRequest",
+    "MCPResponse",
+    "JSONRPCErrorCode",
+    "StreamChunk",
+]
+

--- a/mcp_server/services/scanners/__init__.py
+++ b/mcp_server/services/scanners/__init__.py
@@ -1,1 +1,10 @@
-﻿
+"""Scanner service exports."""
+
+from .angular_scanner import AngularScannerService
+from .csharp_scanner import CSharpScannerService
+
+__all__ = [
+    "AngularScannerService",
+    "CSharpScannerService",
+]
+

--- a/mcp_server/services/vector_store/__init__.py
+++ b/mcp_server/services/vector_store/__init__.py
@@ -1,1 +1,6 @@
-﻿
+"""Vector store service exports."""
+
+from .qdrant_service import QdrantVectorService
+
+__all__ = ["QdrantVectorService"]
+

--- a/mcp_server/transports/__init__.py
+++ b/mcp_server/transports/__init__.py
@@ -1,1 +1,12 @@
-﻿
+"""Transport implementations for MCP Server."""
+
+from .base import Transport, StdioTransport, TCPTransport
+from .websocket import WebSocketTransport
+
+__all__ = [
+    "Transport",
+    "StdioTransport",
+    "TCPTransport",
+    "WebSocketTransport",
+]
+


### PR DESCRIPTION
## Summary
- remove BOM-only contents in package `__init__` files
- define package exports for config, core, models, transports, and services

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_b_683abf2b83a083238bdf1c5ab4087a19