### PR TITLE
Improve MVC pattern detection

### DIFF
--- a/mcp_server/services/knowledge_extraction/call_graph_analyzer.py
+++ b/mcp_server/services/knowledge_extraction/call_graph_analyzer.py
@@ -533,22 +533,40 @@ class CallGraphAnalyzer:
         patterns = []
         
         # Check for MVC pattern
-        mvc_components = {
-            "controllers": 0,
-            "models": 0,
-            "views": 0
+        mvc_sets = {
+            "controllers": set(),
+            "models": set(),
+            "views": set()
         }
-        
+
         for node_id in self.call_graph.nodes():
             node_data = self.call_graph.nodes[node_id]
-            
-            # Check node name for pattern indicators
-            if "controller" in node_id.lower():
-                mvc_components["controllers"] += 1
-            elif "model" in node_id.lower():
-                mvc_components["models"] += 1
-            elif "view" in node_id.lower():
-                mvc_components["views"] += 1
+
+            node_name = node_id.lower()
+            class_name = str(node_data.get("class_name", "")).lower()
+            file_path = str(node_data.get("file_path", "")).lower()
+
+            # Determine if this node represents a controller, model, or view
+            if (
+                "controller" in node_name
+                or "controller" in class_name
+                or "controllers" in file_path
+            ):
+                mvc_sets["controllers"].add(node_id)
+            elif (
+                "model" in node_name
+                or "model" in class_name
+                or "models" in file_path
+            ):
+                mvc_sets["models"].add(node_id)
+            elif (
+                "view" in node_name
+                or "view" in class_name
+                or "views" in file_path
+            ):
+                mvc_sets["views"].add(node_id)
+
+        mvc_components = {k: len(v) for k, v in mvc_sets.items()}
         
         # If we have all three MVC components, it's likely an MVC pattern
         if all(count > 0 for count in mvc_components.values()):

--- a/tests/test_pattern_extractor.py
+++ b/tests/test_pattern_extractor.py
@@ -8,6 +8,7 @@ import shutil
 from unittest.mock import patch, MagicMock, AsyncMock
 
 from mcp_server.services.knowledge_extraction.pattern_extractor import PatternExtractor
+from mcp_server.services.knowledge_extraction.call_graph_analyzer import CallGraphAnalyzer
 
 class TestPatternExtractor:
     
@@ -332,3 +333,46 @@ class TestPatternExtractor:
         
         assert not any("node_modules" in source for source in all_sources)
         assert not any(".min.js" in source for source in all_sources)
+
+
+@pytest.mark.asyncio
+async def test_mvc_detection_with_folder_names():
+    """CallGraphAnalyzer should detect MVC pattern using folder names."""
+    repo_dir = tempfile.mkdtemp()
+
+    try:
+        os.makedirs(os.path.join(repo_dir, "controllers"), exist_ok=True)
+        os.makedirs(os.path.join(repo_dir, "models"), exist_ok=True)
+        os.makedirs(os.path.join(repo_dir, "views"), exist_ok=True)
+
+        files = [
+            {
+                "file_path": os.path.join(repo_dir, "controllers", "user_controller.py"),
+                "code_language": "python",
+                "classes": [{"name": "UserController", "methods": []}],
+            },
+            {
+                "file_path": os.path.join(repo_dir, "models", "user_model.py"),
+                "code_language": "python",
+                "classes": [{"name": "UserModel", "methods": []}],
+            },
+            {
+                "file_path": os.path.join(repo_dir, "views", "user_view.py"),
+                "code_language": "python",
+                "functions": [{"name": "render_user"}],
+            },
+        ]
+
+        analyzer = CallGraphAnalyzer()
+        results = await analyzer.analyze_codebase(repo_dir, files)
+
+        patterns = results.get("patterns", [])
+        mvc = next((p for p in patterns if "MVC" in p["name"]), None)
+
+        assert mvc is not None, "MVC pattern not detected"
+        assert mvc["components"]["controllers"] == 1
+        assert mvc["components"]["models"] == 1
+        assert mvc["components"]["views"] == 1
+    finally:
+        shutil.rmtree(repo_dir)
+


### PR DESCRIPTION
## Summary
- enhance `_identify_architectural_patterns` to combine class names with folder paths
- report counts of MVC components
- test MVC detection using folder structure

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_683c053506e08323b46fc6e1b09821c4